### PR TITLE
Include last trackpoint of loaded gpx file

### DIFF
--- a/geopard/__init__.py
+++ b/geopard/__init__.py
@@ -1,2 +1,0 @@
-from .geopard import *
-from .version import __version__

--- a/geopard/geopard.py
+++ b/geopard/geopard.py
@@ -206,7 +206,7 @@ class Geopard:
         for track in gpx_data.tracks: 
             for segment in track.segments: 
 
-                for i in range(0,len(segment.points)-1):
+                for i in range(0,len(segment.points)):
                     trkp_point = segment.points[i]
                     trkp_lat.append(trkp_point.latitude)
                     trkp_lon.append(trkp_point.longitude)


### PR DESCRIPTION
We had cases, where tracks with a single trackpoint inside the finish radius or polygon did not pass the matching. At processing time, the last point was already dropped caused by this off by one error.

Or is there any reason to not include the last trackpoint?